### PR TITLE
Fix breaking changes - NavData load fails

### DIFF
--- a/Airspace.xml
+++ b/Airspace.xml
@@ -7109,7 +7109,7 @@
       <Runway Name="03" Position="-232211.430-1493146.980"/>
       <Runway Name="21" Position="-232138.930-1493107.590"/>
     </Airport>
-    <Airport ICAO="NTGY" Position="-204648.000-1383401.000" Elevation="">
+    <Airport ICAO="NTGY" Position="-204648.000-1383401.000" Elevation="10">
       <Runway Name="18" Position="-204643.570-1383400.090"/>
       <Runway Name="36" Position="-204724.930-1383409.390"/>
     </Airport>


### PR DESCRIPTION
In the latest version of vatSys, the nav data load is more strict. The empty elevation of NTGY was causing a load failure.

Fixed, and tested - no issues.